### PR TITLE
Fix make args with quoted values

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/ci"
+    directories:
+      - "/"
+      - "/ci"
+      - "/deploy"
+      - "/prepare-env"
     schedule:
-      interval: "daily"
-
-  - package-ecosystem: "github-actions"
-    directory: "/deploy"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "github-actions"
-    directory: "/prepare-env"
-    schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       - "/prepare-env"
     schedule:
       interval: "weekly"
+    groups:
+      actions-major:
+        update-types:
+          - "major"
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Reusable composite GitHub Actions for building and deploying Sphinx documentation sites. Used by other JETHOME-IOT repositories as shared CI/CD components.
+
+## Architecture
+
+Three composite actions, each in its own directory:
+
+- **prepare-env/** — Sets up Python with pip caching via `actions/setup-python`, installs dependencies from `requirements.txt` (of the calling repo)
+- **ci/** — Runs `make <target>` to build Sphinx docs, captures warnings to `warning.txt`, optionally fails on warnings, optionally uploads `_build/html` as artifact
+- **deploy/** — Deploys built HTML via rsync over SSH (using `shimataro/ssh-key-action` for key setup)
+
+Typical workflow in a consuming repo: `prepare-env` -> `ci` -> `deploy`.
+
+## Key Constraints
+
+- All CI jobs in consuming repos use `runs-on: self-hosted` — never GitHub-hosted runners
+- Actions require self-hosted runner >= 2.327.1 (Node.js 24 runtime)
+- Dependabot monitors all three action directories for GitHub Actions updates (`.github/dependabot.yml`)
+
+## Action Versions (as of 2026-03)
+
+| Action | Version | Verify |
+|--------|---------|--------|
+| `actions/upload-artifact` | @v7 | `gh api repos/actions/upload-artifact/releases/latest --jq .tag_name` |
+| `actions/setup-python` | @v6 | `gh api repos/actions/setup-python/releases/latest --jq .tag_name` |
+| `shimataro/ssh-key-action` | @v2 | `gh api repos/shimataro/ssh-key-action/releases/latest --jq .tag_name` |

--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -38,7 +38,7 @@ runs:
         fi
 
     - name: ℹ️ Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ inputs.upload_artifact=='true' }}
       with:
         name: HTMLOutput

--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -28,11 +28,15 @@ runs:
 
     - name: 🚀 Build CI
       shell: bash
+      env:
+        MAKE_TARGET: ${{ inputs.target }}
+        MAKE_ARGS: ${{ inputs.env }}
+        STOP_ON_WARNING: ${{ inputs.stop-on-warning }}
       run: |
-        make ${{ inputs.target }} ${{ inputs.env }}  2> >(tee warning.txt)
+        make "$MAKE_TARGET" $MAKE_ARGS 2> >(tee warning.txt)
         if [[ -s warning.txt ]]; then
           echo ---------------------- Found warnings in build ----------------------
-          if [[ "${{ inputs.stop-on-warning }}" == "true" ]]; then
+          if [[ "$STOP_ON_WARNING" == "true" ]]; then
             exit 100
           fi
         fi

--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -30,10 +30,9 @@ runs:
       shell: bash
       env:
         MAKE_TARGET: ${{ inputs.target }}
-        MAKE_ARGS: ${{ inputs.env }}
         STOP_ON_WARNING: ${{ inputs.stop-on-warning }}
       run: |
-        make "$MAKE_TARGET" $MAKE_ARGS 2> >(tee warning.txt)
+        make "$MAKE_TARGET" ${{ inputs.env }} 2> >(tee warning.txt)
         if [[ -s warning.txt ]]; then
           echo ---------------------- Found warnings in build ----------------------
           if [[ "$STOP_ON_WARNING" == "true" ]]; then

--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -1,5 +1,5 @@
 name: Do CD
-description: Do build check
+description: Deploy built site
 
 inputs:
   build_out:
@@ -28,7 +28,7 @@ runs:
 
     - name: Install SSH key for storage
       uses: shimataro/ssh-key-action@v2
-      if: ${{ inputs.deploy_mode == 'rsync' }} && ${{ inputs.ssh_key != '' }}
+      if: ${{ inputs.deploy_mode == 'rsync' && inputs.ssh_key != '' }}
       with:
         key: ${{ inputs.ssh_key }}
         known_hosts: ${{ inputs.ssh_hostkey }}
@@ -37,8 +37,12 @@ runs:
     - name: Deploy
       if: ${{ inputs.deploy_mode == 'rsync' }}
       shell: bash
+      env:
+        BUILD_OUT: ${{ inputs.build_out }}
+        DEPLOY_HOST: ${{ inputs.deploy_host }}
+        DEPLOY_DIR: ${{ inputs.deploy_dir }}
       run: |
-          rsync -avz --delete ${{ inputs.build_out }}/ ${{ inputs.deploy_host }}:${{ inputs.deploy_dir }}
+          rsync -avz --delete "$BUILD_OUT"/ "$DEPLOY_HOST":"$DEPLOY_DIR"
 
     - name: Unsupported mode
       if: ${{ inputs.deploy_mode != 'rsync' }}

--- a/prepare-env/action.yaml
+++ b/prepare-env/action.yaml
@@ -1,5 +1,5 @@
 name: Prepare Python venv
-description: Prepare Python virtualenv in .venv. Works only on amd64
+description: Set up Python and install pip dependencies
 
 inputs:
   python-version:

--- a/prepare-env/action.yaml
+++ b/prepare-env/action.yaml
@@ -5,13 +5,13 @@ inputs:
   python-version:
     description: 'Python version to use'
     required: true
-    default: '3.12'
+    default: '3.13'
 
 runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'


### PR DESCRIPTION
## Summary

- Fix `inputs.env` handling in ci action: keep as direct `${{ }}` interpolation instead of env var

The `env` input (e.g. `SPHINXOPTS="-t Internal"`) is a shell fragment that needs shell-level parsing. Putting it in an env var and using `$MAKE_ARGS` breaks word splitting because quotes inside variable expansion are not interpreted as shell syntax.

Fixes build failure: https://github.com/jethome-iot/docs/actions/runs/23295900438/job/67743077491

## Test plan

- [ ] Re-run the failed CI in jethome-iot/docs

Generated with [Claude Code](https://claude.ai/code)