### PR TITLE
Fix make args with quoted values

### DIFF
--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -30,10 +30,9 @@ runs:
       shell: bash
       env:
         MAKE_TARGET: ${{ inputs.target }}
-        MAKE_ARGS: ${{ inputs.env }}
         STOP_ON_WARNING: ${{ inputs.stop-on-warning }}
       run: |
-        make "$MAKE_TARGET" $MAKE_ARGS 2> >(tee warning.txt)
+        make "$MAKE_TARGET" ${{ inputs.env }} 2> >(tee warning.txt)
         if [[ -s warning.txt ]]; then
           echo ---------------------- Found warnings in build ----------------------
           if [[ "$STOP_ON_WARNING" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Keep `inputs.env` as direct `${{ }}` interpolation instead of env var in ci action

The `env` input (e.g. `SPHINXOPTS="-t Internal"`) is a shell fragment that needs shell-level parsing. Putting it in an env var and using `$MAKE_ARGS` breaks word splitting because quotes inside variable expansion are not interpreted as shell syntax.

Fixes: https://github.com/jethome-iot/docs/actions/runs/23295900438/job/67743077491

## Test plan

- [ ] Re-run the failed CI in jethome-iot/docs

Generated with [Claude Code](https://claude.ai/code)